### PR TITLE
refactor:change incompatible code

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { render } from 'react-dom'
 import { createRoot } from 'react-dom/client';
 import PropTypes from 'prop-types'
 

--- a/index.jsx
+++ b/index.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { render } from 'react-dom'
+import { createRoot } from 'react-dom/client';
 import PropTypes from 'prop-types'
 
 // default Provider
@@ -26,7 +27,8 @@ const renderModal = (Template, props) => {
       <Template {...props} />
     </Container>
   )
-  render(template, dom)
+  
+  createRoot(dom).render(template)
   return dom
 }
 


### PR DESCRIPTION
根据React 18 Api升级文档:
[How to Upgrade to React 18](https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-client-rendering-apis)
采用了一些新的API替换了旧版本的代码